### PR TITLE
Added github repo to dist metadata and doc

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Perl module Tangerine
 0.17 2015-05-??
 - Added [GithubMeta] to dist.ini, so the repo will be listed in the
   dist metadata.
+- Added [MetaJSON] to dist.ini, so the release will include a META.json file
 
 0.16 2015-05-13
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+Revision history for Perl module Tangerine
+
+0.17 2015-05-??
+- Added [GithubMeta] to dist.ini, so the repo will be listed in the
+  dist metadata.
+
 0.16 2015-05-13
 
 - No longer ignore numeric module names.  Apparently it's allowed in

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Tangerine
-version = 0.16
+version = 0.17
 author  = Petr Šabata <contyk@redhat.com>
 license = MIT
 copyright_holder = Petr Šabata
@@ -25,6 +25,7 @@ Test::More              = 0
 [ExtraTests]
 [PodSyntaxTests]
 [PkgVersion]
+[GithubMeta]
 
 [TestRelease]
 [ConfirmRelease]

--- a/dist.ini
+++ b/dist.ini
@@ -25,6 +25,7 @@ Test::More              = 0
 [ExtraTests]
 [PodSyntaxTests]
 [PkgVersion]
+[MetaJSON]
 [GithubMeta]
 
 [TestRelease]

--- a/lib/Tangerine.pm
+++ b/lib/Tangerine.pm
@@ -218,6 +218,10 @@ Deprecated.  These are provided for backwards compatibility only.
 
 L<Tangerine::Occurence>
 
+=head1 REPOSITORY
+
+L<https://github.com/contyk/tangerine.pm>
+
 =head1 AUTHOR
 
 Petr Šabata <contyk@redhat.com>


### PR DESCRIPTION
Hi Petr,

This pull request adds the github repo to the dist's metadata. That means that it will be listed in the sidebar on MetaCPAN, when people look at this dist, and also that other tools can find it. For example that will make it a candidate for assignment in the [CPAN Pull Request Challenge](http://cpan-prc.org).

I also added [MetaJSON], so that the release tarball will include a META.json -- it supports some things that META.yml doesn't support, and various tools will read the META.json in preference to the META.yml.

Cheers,
Neil
